### PR TITLE
Fixed 🌟Notable Projects links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ US high school student interested in reverse engineering and low-level code anal
 <details>
 <summary>:star2: Notable Projects</summary>
   
-<p align="center"><a href="https://github.com/NtTuna/SystemPolicyInfo"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=SystemPolicyInfo" /> 
-<p align="center"><a href="https://github.com/NtTuna/GD-Editor-Leak"><img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=GD-Editor-Leak" /> </a>
-<p align="center"><a href="https://github.com/NtTuna/photon"><img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=photon" /> 
-<p align="center"><a href="https://github.com/NtTuna/StudentVue-rs"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=StudentVue-rs" /> 
-<p align="center"><a href="https://github.com/NtTuna/BadlionLogger"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=BadlionLogger" /> 
-<p align="center"><a href="https://github.com/NtTuna/AsIO-Exploit"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=AsIO-Exploit" /> 
+<p align="center"><a href="https://github.com/NtTuna/SystemPolicyInfo"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=SystemPolicyInfo" /> 
+<p align="center"><a href="https://github.com/NtTuna/GD-Editor-Leak"><img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=GD-Editor-Leak" /> </a>
+<p align="center"><a href="https://github.com/NtTuna/photon"><img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=photon" /> 
+<p align="center"><a href="https://github.com/NtTuna/StudentVue-rs"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=StudentVue-rs" /> 
+<p align="center"><a href="https://github.com/NtTuna/BadlionLogger"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=BadlionLogger" /> 
+<p align="center"><a href="https://github.com/NtTuna/AsIO-Exploit"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=AsIO-Exploit" /> 
 
 </details>
 


### PR DESCRIPTION
* ### **Fixed Notable Project Links**
Links broke after `encls` changed his name to `NtTuna`

Before the fix, the README used to look like this.
![unknown](https://user-images.githubusercontent.com/52223947/133728553-d82062eb-f8c9-4f1b-b7da-361fb1e88987.png)

Now it looks like this after the fix.
![unknown (1)](https://user-images.githubusercontent.com/52223947/133728682-0d77bdf5-4adc-4e33-b560-e67ccb9520d0.png)

* ### **How was it fixed?**
The fix is pretty simple, changing the `username` value in the links in the lines `9, 10, 11, 12, 13, 14` to `NtTuna` we can fix this.

* ### **Example**
Changing the line number 9 in README.md
`<p align="center"><a href="https://github.com/NtTuna/SystemPolicyInfo"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=encls&repo=SystemPolicyInfo" />`
to
`<p align="center"><a href="https://github.com/NtTuna/SystemPolicyInfo"> <img src="https://github-readme-stats.vercel.app/api/pin/?username=NtTuna&repo=SystemPolicyInfo" />`
